### PR TITLE
Feature/error view

### DIFF
--- a/GenshinArtifactScorable.xcodeproj/project.pbxproj
+++ b/GenshinArtifactScorable.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		082077D829D3F05200854579 /* AccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082077D729D3F05200854579 /* AccountService.swift */; };
 		0842FA6729D3395F008CD2AC /* AppResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0842FA6629D3395F008CD2AC /* AppResource.swift */; };
 		0842FA6A29D34B01008CD2AC /* CharacterCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0842FA6929D34B01008CD2AC /* CharacterCollectionViewCell.xib */; };
+		0849F1452A55261F00E42E32 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0849F1442A55261F00E42E32 /* ErrorView.swift */; };
+		0849F14F2A55325A00E42E32 /* ErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0849F14E2A55325A00E42E32 /* ErrorView.xib */; };
 		0868FEEA29C443EF000AC079 /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0868FEE929C443EF000AC079 /* NSObject+.swift */; };
 		0868FEEC29C44575000AC079 /* Storyboardable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0868FEEB29C44575000AC079 /* Storyboardable.swift */; };
 		0868FEEF29C44F27000AC079 /* SelectCharacterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0868FEEE29C44F27000AC079 /* SelectCharacterViewController.swift */; };
@@ -86,6 +88,8 @@
 		082077D729D3F05200854579 /* AccountService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountService.swift; sourceTree = "<group>"; };
 		0842FA6629D3395F008CD2AC /* AppResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppResource.swift; sourceTree = "<group>"; };
 		0842FA6929D34B01008CD2AC /* CharacterCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CharacterCollectionViewCell.xib; sourceTree = "<group>"; };
+		0849F1442A55261F00E42E32 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
+		0849F14E2A55325A00E42E32 /* ErrorView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ErrorView.xib; sourceTree = "<group>"; };
 		0868FEE929C443EF000AC079 /* NSObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
 		0868FEEB29C44575000AC079 /* Storyboardable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storyboardable.swift; sourceTree = "<group>"; };
 		0868FEEE29C44F27000AC079 /* SelectCharacterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCharacterViewController.swift; sourceTree = "<group>"; };
@@ -222,6 +226,15 @@
 				0898313C29D3FC6300D9E5C8 /* CharacterCollectionViewCell.swift */,
 			);
 			path = Component;
+			sourceTree = "<group>";
+		};
+		0849F1432A5525FC00E42E32 /* ErrorView */ = {
+			isa = PBXGroup;
+			children = (
+				0849F1442A55261F00E42E32 /* ErrorView.swift */,
+				0849F14E2A55325A00E42E32 /* ErrorView.xib */,
+			);
+			path = ErrorView;
 			sourceTree = "<group>";
 		};
 		0868FEDD29C43821000AC079 /* App */ = {
@@ -409,6 +422,7 @@
 		08D8F0B92A40AA2B00F322CA /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				0849F1432A5525FC00E42E32 /* ErrorView */,
 				08D8F0BC2A40ABF600F322CA /* LoadingView.xib */,
 				08D8F0BE2A40AD1B00F322CA /* LoadingView.swift */,
 			);
@@ -563,6 +577,7 @@
 				08FABADE2A2C86E4000C0C9A /* SearchHistoryTableViewCell.xib in Resources */,
 				088A4F0129E99ED300F99D85 /* ja-jp.ttf in Resources */,
 				088A4EEE29E7FF9300F99D85 /* namecards.json in Resources */,
+				0849F14F2A55325A00E42E32 /* ErrorView.xib in Resources */,
 				08D13C3B2A22076C00EBBC2C /* BuildCardGenerator.storyboard in Resources */,
 				08D8F0BD2A40ABF600F322CA /* LoadingView.xib in Resources */,
 				08694CAC298A51F100FC98F8 /* Main.storyboard in Resources */,
@@ -719,6 +734,7 @@
 				082077D329D3F04300854579 /* AccountTarget.swift in Sources */,
 				08FABADC2A2C86CB000C0C9A /* SearchHistoryTableViewCell.swift in Sources */,
 				0868FEEF29C44F27000AC079 /* SelectCharacterViewController.swift in Sources */,
+				0849F1452A55261F00E42E32 /* ErrorView.swift in Sources */,
 				082077D529D3F04300854579 /* API.swift in Sources */,
 				0898314729E5800E00D9E5C8 /* Scorable.swift in Sources */,
 				088A4EF629E80A8A00F99D85 /* Localized.swift in Sources */,

--- a/GenshinArtifactScorable/App/AppError.swift
+++ b/GenshinArtifactScorable/App/AppError.swift
@@ -7,17 +7,67 @@
 
 import Foundation
 
-protocol CauseTraceable {
-    var causeError: Error? { get }
-}
-
 enum APIError: Error {
-    case invalidData
+    enum HTTPStatusCodeError: Error {
+        
+        /// 400
+        case badRequest
+        
+        /// 404
+        case notFound
+        
+        /// 424
+        case failedDependency
+        
+        /// 429
+        case tooManyRequests
+        
+        /// 500
+        case internalServerError
+        
+        /// 503
+        case serviceUnavailable
+        
+        /// 200番台(成功)以外で上記以外の番号
+        case unknown(Int)
+        
+        // MARK: - Initializer
+        
+        init(statusCode: Int) {
+            switch statusCode {
+            case 400:
+                self = .badRequest
+            case 404:
+                self = .notFound
+            case 424:
+                self = .failedDependency
+            case 429:
+                self = .tooManyRequests
+            case 500:
+                self = .internalServerError
+            case 503:
+                self = .serviceUnavailable
+            default:
+                self = .unknown(statusCode)
+            }
+        }
+    }
+    
+    /// 200番台以外のステータスコードが返ってきた
+    case statusCode(HTTPStatusCodeError)
+    
+    /// レスポンスのデコードに失敗した
+    case decode(Error)
+    
+    /// レスポンスを受け取れなかった(ネットワーク不良など)
+    case response(Error)
+    
+    /// 同一UIDに対して短時間に複数リクエストをした
     case refreshTooFast(dateWhenRefreshable: Date)
 }
 
-enum FileReadError: Error {
-    
+enum ImageAPIError: Error {
+    case invalidData
 }
 
 enum AppResourceError: Error {
@@ -29,21 +79,11 @@ enum ImageCachesManagerError: Error {
     case write(Error)
 }
 
-enum DataStoreError: Error, CauseTraceable {
+enum DataStoreError: Error {
 
     /// トランザクションが失敗した
     case transaction(Error)
 
     /// 指定したオブジェクトが存在しない
     case notFound(String)
-
-    var causeError: Error? {
-        switch self {
-        case .transaction(let error):
-            return error
-
-        case .notFound:
-            return nil
-        }
-    }
 }

--- a/GenshinArtifactScorable/Model/ShapedAccountAllInfo.swift
+++ b/GenshinArtifactScorable/Model/ShapedAccountAllInfo.swift
@@ -380,13 +380,17 @@ struct Attribute {
     
     // %表記が必要なステータスは%付きのStringを返す
     var valueString: String {
-        if propId.contains("PERCENT") || propId.contains("HURT") || propId.contains("CRITICAL") || propId.contains("CHARGE") {
+        if isPercentValue() {
             return "\(String(format: "%.1f", value))%"
         } else {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             return formatter.string(from: value as NSNumber) ?? String(format: "%.0f", value)
         }
+    }
+    
+    private func isPercentValue() -> Bool {
+        return propId.contains("PERCENT") || propId.contains("HURT") || propId.contains("CRITICAL") || propId.contains("CHARGE") || propId.contains("HEAL_ADD")
     }
     
     init(propId: String, name: String, value: Double) {

--- a/GenshinArtifactScorable/Network/ImageAPI.swift
+++ b/GenshinArtifactScorable/Network/ImageAPI.swift
@@ -30,7 +30,7 @@ final class ImageAPI {
                     if let image = UIImage(data: result.data) {
                         resolver.fulfill(image)
                     } else {
-                        resolver.reject(APIError.invalidData)
+                        resolver.reject(ImageAPIError.invalidData)
                     }
                 case .failure(let error):
                     resolver.reject(error)

--- a/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.swift
+++ b/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.swift
@@ -1,0 +1,32 @@
+//
+//  ErrorView.swift
+//  GenshinArtifactScorable
+//
+//  Created by hide on 2023/07/05.
+//
+
+import UIKit
+
+final class ErrorView: UIView {
+    
+    // MARK: - Private
+    
+    private var refreshButtonHandler: (() -> Void)?
+    
+    // MARK: - Public
+    
+    func setRefreshButtonHandler(handler: @escaping () -> Void) {
+        self.refreshButtonHandler = handler
+    }
+    
+    // MARK: - Action
+    
+    @IBAction func refreshButtonDidTap(_ sender: Any) {
+        refreshButtonHandler?()
+    }
+}
+
+extension ErrorView: NibInstantiatable {
+    func inject(_ dependency: ()) {
+    }
+}

--- a/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.xib
+++ b/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.xib
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="7MA-Ax-3Kf" customClass="ErrorView" customModule="GenshinArtifactScorable" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="SRU-NJ-1XT">
+                    <rect key="frame" x="104.66666666666667" y="389.33333333333331" width="183.66666666666663" height="73.333333333333314"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題が発生しました" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4k2-hI-iZv">
+                            <rect key="frame" x="0.0" y="0.0" width="183.66666666666666" height="24"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hFT-hm-ziL">
+                            <rect key="frame" x="55.333333333333329" y="40" width="72.999999999999986" height="33.333333333333343"/>
+                            <color key="tintColor" systemColor="labelColor"/>
+                            <state key="normal" title="Button"/>
+                            <buttonConfiguration key="configuration" style="gray" title="再試行">
+                                <fontDescription key="titleFontDescription" type="system" pointSize="16"/>
+                            </buttonConfiguration>
+                            <connections>
+                                <action selector="refreshButtonDidTap:" destination="7MA-Ax-3Kf" eventType="touchUpInside" id="oXq-rf-DNu"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="Hg1-jC-bb8"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="SRU-NJ-1XT" firstAttribute="centerY" secondItem="7MA-Ax-3Kf" secondAttribute="centerY" id="Pf4-mW-cZX"/>
+                <constraint firstItem="SRU-NJ-1XT" firstAttribute="centerX" secondItem="7MA-Ax-3Kf" secondAttribute="centerX" id="pgX-Px-yTq"/>
+            </constraints>
+            <point key="canvasLocation" x="-1179" y="-379"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/GenshinArtifactScorable/Presentation/Screen/BuildCardGenerator/BuildCardGeneratorViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/BuildCardGenerator/BuildCardGeneratorViewController.swift
@@ -30,13 +30,20 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
     private var artifactImages: [UIImage?]!
     
     private var isArtifactEquipedArray: [Bool]!
+    private var isShowingErrorView = false
     
     private var loadingView = LoadingView(with: ())
+    private var errorView = ErrorView(with: ())
     
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        errorView.setRefreshButtonHandler { [weak self] in
+            guard let self = self else { return }
+            self.prepareUIImages()
+            self.hideErrorView()
+        }
         prepareUIImages()
     }
     
@@ -53,6 +60,18 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
         loadingView.removeFromSuperview()
     }
     
+    private func showErrorView() {
+        if isShowingErrorView { return }
+        isShowingErrorView = true
+        errorView.frame = view.frame
+        view.addSubview(errorView)
+    }
+    
+    private func hideErrorView() {
+        errorView.removeFromSuperview()
+        isShowingErrorView = false
+    }
+    
     private func prepareUIImages() {
         showLoadingView()
         imageService.fetchUIImage(imageString: character.imageString)
@@ -60,6 +79,8 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
                 self.characterImage = characterImage
                 self.generateBuildCardIfPrepared()
             }.catch { error in
+                self.showErrorView()
+                self.hideLoadingView()
                 print(error)
             }
         
@@ -68,6 +89,8 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
                 self.weaponImage = weaponImage
                 self.generateBuildCardIfPrepared()
             }.catch { error in
+                self.showErrorView()
+                self.hideLoadingView()
                 print(error)
             }
         
@@ -77,6 +100,8 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
                     self.skillIcons[index] = skillIcon
                     self.generateBuildCardIfPrepared()
                 }.catch { error in
+                    self.showErrorView()
+                    self.hideLoadingView()
                     print(error)
                 }
         }
@@ -87,6 +112,8 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
                     self.constellationIcons[index] = constellationIcon
                     self.generateBuildCardIfPrepared()
                 }.catch { error in
+                    self.showErrorView()
+                    self.hideLoadingView()
                     print(error)
                 }
         }
@@ -110,6 +137,8 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
                     }
                     self.generateBuildCardIfPrepared()
                 }.catch { error in
+                    self.showErrorView()
+                    self.hideLoadingView()
                     print(error)
                 }
         }
@@ -118,7 +147,14 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
     private func generateBuildCardIfPrepared() {
         guard let characterImage = characterImage, let weaponImage = weaponImage else { return }
         if isSkillIconsPrepared(), isArtifactsImagesPrepared(), isConstellationIconsPrepared() {
-            buildCardImageView.image = generateBuildCard(character: character, scoreCalculateType: scoreCalculateType, characterImage: characterImage, weaponImage: weaponImage, skillIcons: skillIcons.map { $0! }, constellationIcons: constellationIcons.map { $0! }, artifactImages: artifactImages)
+            buildCardImageView.image = generateBuildCard(
+                character: character,
+                scoreCalculateType: scoreCalculateType,
+                characterImage: characterImage,
+                weaponImage: weaponImage,
+                skillIcons: skillIcons.map { $0! },
+                constellationIcons: constellationIcons.map { $0! },
+                artifactImages: artifactImages)
             hideLoadingView()
         }
     }

--- a/GenshinArtifactScorable/Presentation/Screen/Main/en.lproj/Main.storyboard
+++ b/GenshinArtifactScorable/Presentation/Screen/Main/en.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
@@ -84,7 +84,6 @@ final class SelectCharacterViewController: UIViewController {
             .done { accountAllInfo in
                 self.shapedAccountAllInfo = accountAllInfo
                 self.characterIcons = Array(repeating: UIImage(), count: accountAllInfo.characters.count)
-                self.isCharacterIconsLoaded = Array(repeating: false, count: accountAllInfo.characters.count)
                 self.setupUI()
             }.catch { error in
                 if let _ = self.shapedAccountAllInfo {
@@ -92,6 +91,7 @@ final class SelectCharacterViewController: UIViewController {
                     self.setupUI()
                 } else {
                     self.showErrorView()
+                    self.hideLoadingView()
                 }
                 print(error)
             }
@@ -124,15 +124,14 @@ final class SelectCharacterViewController: UIViewController {
         isShowingErrorView = false
     }
     
-    private func setupUI() {
-        uidLabel.text = "UID " + uid
-        
-        guard let shapedAccountAllInfo = self.shapedAccountAllInfo else { return }
-        
-        userNameLabel.text = shapedAccountAllInfo.playerBasicInfo.playerName
-        adventureRankLabel.text = String(shapedAccountAllInfo.playerBasicInfo.adventureLevel)
-        worldRankLabel.text = String(shapedAccountAllInfo.playerBasicInfo.worldLevel)
-        statusMessageLabel.text = shapedAccountAllInfo.playerBasicInfo.statusMessage
+    private func resetLoadedFlags(numOfCharacterIcons: Int) {
+        isProfileIconLoaded = false
+        isNameCardImageLoaded = false
+        isCharacterIconsLoaded = Array(repeating: false, count: numOfCharacterIcons)
+    }
+    
+    private func fetchImages(shapedAccountAllInfo: ShapedAccountAllInfo) {
+        resetLoadedFlags(numOfCharacterIcons: shapedAccountAllInfo.characters.count)
         
         imageService.fetchUIImage(imageString: shapedAccountAllInfo.playerBasicInfo.profilePictureCharacterIconString)
             .done { profileIconImage in
@@ -183,6 +182,19 @@ final class SelectCharacterViewController: UIViewController {
                     print(error)
                 }
         }
+    }
+    
+    private func setupUI() {
+        uidLabel.text = "UID " + uid
+        
+        guard let shapedAccountAllInfo = self.shapedAccountAllInfo else { return }
+        
+        userNameLabel.text = shapedAccountAllInfo.playerBasicInfo.playerName
+        adventureRankLabel.text = String(shapedAccountAllInfo.playerBasicInfo.adventureLevel)
+        worldRankLabel.text = String(shapedAccountAllInfo.playerBasicInfo.worldLevel)
+        statusMessageLabel.text = shapedAccountAllInfo.playerBasicInfo.statusMessage
+        
+        fetchImages(shapedAccountAllInfo: shapedAccountAllInfo)
     }
     
     private func isAllUIImagesFetched() -> Bool {

--- a/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
@@ -42,11 +42,13 @@ final class SelectCharacterViewController: UIViewController {
     private var shapedAccountAllInfo: ShapedAccountAllInfo?
     
     private var loadingView = LoadingView(with: ())
+    private var errorView = ErrorView(with: ())
+    
     private var characterIcons: [UIImage] = []
     private var isCharacterIconsLoaded: [Bool] = []
     private var isProfileIconLoaded = false
     private var isNameCardImageLoaded = false
-    private var isInitial = true
+    private var isShowingErrorView = false
     
     private var selectedCalculateType: ScoreCalculateType? {
         didSet {
@@ -66,6 +68,11 @@ final class SelectCharacterViewController: UIViewController {
         super.viewDidLoad()
         generateBuildCardButton.isEnabled = false
         configureMenu()
+        errorView.setRefreshButtonHandler { [weak self] in
+            guard let self = self else { return }
+            self.refreshShapedAccountAllInfo()
+            self.hideErrorView()
+        }
         refreshShapedAccountAllInfo()
     }
     
@@ -81,7 +88,10 @@ final class SelectCharacterViewController: UIViewController {
                 self.setupUI()
             }.catch { error in
                 if let _ = self.shapedAccountAllInfo {
+                    // 通信に失敗してもキャッシュによりnilでなければUIのセットアップをする
                     self.setupUI()
+                } else {
+                    self.showErrorView()
                 }
                 print(error)
             }
@@ -102,6 +112,18 @@ final class SelectCharacterViewController: UIViewController {
         loadingView.removeFromSuperview()
     }
     
+    private func showErrorView() {
+        if isShowingErrorView { return }
+        errorView.frame = view.frame
+        view.addSubview(errorView)
+        isShowingErrorView = true
+    }
+    
+    private func hideErrorView() {
+        errorView.removeFromSuperview()
+        isShowingErrorView = false
+    }
+    
     private func setupUI() {
         uidLabel.text = "UID " + uid
         
@@ -119,7 +141,10 @@ final class SelectCharacterViewController: UIViewController {
                 if self.isAllUIImagesFetched() { self.hideLoadingView() }
             }.catch { error in
                 self.isProfileIconLoaded = true
-                if self.isAllUIImagesFetched() { self.hideLoadingView() }
+                if self.isAllUIImagesFetched() {
+                    self.showErrorView()
+                    self.hideLoadingView()
+                }
                 print(error)
             }
         
@@ -130,7 +155,10 @@ final class SelectCharacterViewController: UIViewController {
                 if self.isAllUIImagesFetched() { self.hideLoadingView() }
             }.catch { error in
                 self.isNameCardImageLoaded = true
-                if self.isAllUIImagesFetched() { self.hideLoadingView() }
+                if self.isAllUIImagesFetched() {
+                    self.showErrorView()
+                    self.hideLoadingView()
+                }
                 print(error)
             }
         
@@ -140,17 +168,18 @@ final class SelectCharacterViewController: UIViewController {
                     self.characterIcons[index] = characterIcon
                     self.isCharacterIconsLoaded[index] = true
                     if self.isCharacterIconsLoaded.allSatisfy({ $0 }) {
-                        self.isInitial = false
                         self.characterCollectionView.reloadData()
                     }
                     if self.isAllUIImagesFetched() { self.hideLoadingView() }
                 }.catch { error in
                     self.isCharacterIconsLoaded[index] = true
                     if self.isCharacterIconsLoaded.allSatisfy({ $0 }) {
-                        self.isInitial = false
                         self.characterCollectionView.reloadData()
                     }
-                    if self.isAllUIImagesFetched() { self.hideLoadingView() }
+                    if self.isAllUIImagesFetched() {
+                        self.showErrorView()
+                        self.hideLoadingView()
+                    }
                     print(error)
                 }
         }
@@ -217,7 +246,7 @@ extension SelectCharacterViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeue(CharacterCollectionViewCell.reusable, for: indexPath)
-        if !isInitial, let shapedAccountAllInfo = shapedAccountAllInfo {
+        if let shapedAccountAllInfo = shapedAccountAllInfo, characterIcons.count == shapedAccountAllInfo.characters.count {
             cell.inject((shapedAccountAllInfo.characters[indexPath.row], characterIcons[indexPath.row]))
         }
         return cell


### PR DESCRIPTION
## 概要
- 通信に失敗した際に`ErrorView`を表示する機能を追加
- APIエラーのケースを追加

## 実装
### `ErrorView`
- `ErrorView`はメッセージと再試行ボタンから構成される
- ボタン押下時の処理について，`ErrorView`を保持する`ViewController`の`viewDidLoad()`内で`setRefreshButtonHandler(handler)`を呼ぶことで設定する
- ユーザ情報画面にて，`ErrorView`のボタンより再試行を行った時，通信済みか否かのフラグをリセットし，正しくフラグ管理できるように
### APIエラー
- ステータスコードに応じたエラーケースを追加
- レスポンスのデコード失敗時のエラーを追加
- レスポンスの受け取り失敗時のエラーを追加
- API.swift内，`createError(error: MoyaError)`により，Moyaから返ってきたエラーケースに応じてカスタムエラーを構築して返す
- `MoyaError`のエラーケースについて，`.statusCode`と`.underlying`とその他いくつかケースがある．しかし，ステータスコードエラーに関しても`.underlying`ケースで返ってきてるっぽい？そのため`.underlying`ケースであった場合でもステータスコードのカスタムエラーを返すように．`.statusCode`ケースはどのような時に返ってくるかは不明

## 画面
<img src="https://github.com/hide9201/GenshinArtifactScorable/assets/65844566/afd1988e-241c-4f36-85f2-11b3f29ae516" width=240>



