### PR TITLE
Feature/fix api

### DIFF
--- a/GenshinArtifactScorable/App/AppConstant.swift
+++ b/GenshinArtifactScorable/App/AppConstant.swift
@@ -10,4 +10,9 @@ enum AppConstant {
     enum API {
         static let baseURL = "https://enka.network"
     }
+    
+    enum ErrorViewTitle {
+        static let pleaseRefresh = "再読み込みしてください"
+        static let errorOccured = "問題が発生しました"
+    }
 }

--- a/GenshinArtifactScorable/App/AppError.swift
+++ b/GenshinArtifactScorable/App/AppError.swift
@@ -53,21 +53,26 @@ enum APIError: Error {
         }
     }
     
+    enum AccountAPIError: Error {
+        
+        /// レスポンスのデコードに失敗した
+        case decode(Error)
+        
+        /// 同一UIDに対して短時間に複数リクエストをした
+        case refreshTooFast(dateWhenRefreshable: Date)
+    }
+    
+    enum ImageAPIError: Error {
+        
+        /// UIImageに変換できないデータだった
+        case invalidData
+    }
+    
     /// 200番台以外のステータスコードが返ってきた
     case statusCode(HTTPStatusCodeError)
     
-    /// レスポンスのデコードに失敗した
-    case decode(Error)
-    
     /// レスポンスを受け取れなかった(ネットワーク不良など)
     case response(Error)
-    
-    /// 同一UIDに対して短時間に複数リクエストをした
-    case refreshTooFast(dateWhenRefreshable: Date)
-}
-
-enum ImageAPIError: Error {
-    case invalidData
 }
 
 enum AppResourceError: Error {

--- a/GenshinArtifactScorable/Model/Scorable.swift
+++ b/GenshinArtifactScorable/Model/Scorable.swift
@@ -40,7 +40,7 @@ enum ScoreCalculateType: CaseIterable {
     case energyRecharge
     case elementalMastery
     
-    var calculateTypeString: String {
+    var typeName: String {
         switch self {
         case .attack:
             return "攻撃％"
@@ -55,7 +55,7 @@ enum ScoreCalculateType: CaseIterable {
         }
     }
     
-    var propIconString: String {
+    var typeIconString: String {
         switch self {
         case .attack:
             return "PropIcon/ATTACK_PERCENT"

--- a/GenshinArtifactScorable/Network/API.swift
+++ b/GenshinArtifactScorable/Network/API.swift
@@ -36,7 +36,7 @@ final class API {
                     do {
                         resolver.fulfill(try self.decoder.decode(T.self, from: result.data))
                     } catch {
-                        resolver.reject(APIError.decode(error))
+                        resolver.reject(APIError.AccountAPIError.decode(error))
                     }
                 case .failure(let error):
                     resolver.reject(self.createError(from: error))

--- a/GenshinArtifactScorable/Network/Target/ImageTarget.swift
+++ b/GenshinArtifactScorable/Network/Target/ImageTarget.swift
@@ -30,7 +30,7 @@ extension ImageTarget: BaseTarget {
     
     var task: Task {
         switch self {
-        case .fetchUIImage(_):
+        case .fetchUIImage:
             return .requestPlain
         }
     }

--- a/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.swift
+++ b/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.swift
@@ -9,6 +9,11 @@ import UIKit
 
 final class ErrorView: UIView {
     
+    // MARK: - Outlet
+    
+    @IBOutlet weak var refreshButton: UIButton!
+    @IBOutlet weak var titleLabel: UILabel!
+    
     // MARK: - Private
     
     private var refreshButtonHandler: (() -> Void)?
@@ -27,6 +32,8 @@ final class ErrorView: UIView {
 }
 
 extension ErrorView: NibInstantiatable {
-    func inject(_ dependency: ()) {
+    func inject(_ dependency: (title: String, hideRefreshButton: Bool)) {
+        titleLabel.text = dependency.title
+        refreshButton.isHidden = dependency.hideRefreshButton
     }
 }

--- a/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.xib
+++ b/GenshinArtifactScorable/Presentation/Common/ErrorView/ErrorView.xib
@@ -44,6 +44,10 @@
                 <constraint firstItem="SRU-NJ-1XT" firstAttribute="centerY" secondItem="7MA-Ax-3Kf" secondAttribute="centerY" id="Pf4-mW-cZX"/>
                 <constraint firstItem="SRU-NJ-1XT" firstAttribute="centerX" secondItem="7MA-Ax-3Kf" secondAttribute="centerX" id="pgX-Px-yTq"/>
             </constraints>
+            <connections>
+                <outlet property="refreshButton" destination="hFT-hm-ziL" id="1j0-4K-u4F"/>
+                <outlet property="titleLabel" destination="4k2-hI-iZv" id="ADa-8C-tzw"/>
+            </connections>
             <point key="canvasLocation" x="-1179" y="-379"/>
         </view>
     </objects>

--- a/GenshinArtifactScorable/Presentation/Screen/BuildCardGenerator/BuildCardGeneratable.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/BuildCardGenerator/BuildCardGeneratable.swift
@@ -405,7 +405,7 @@ extension BuildCardGeneratable {
         totalScoreGradeIcon.draw(in: CGRect(x: totalScoreGradeIconX, y: totalScoreGradeIconY, width: totalScoreGradeIconWidth, height: totalScoreGradeIconHeight))
         
         let scoreCalculateTypeFont = UIFont(name: genshinUIFontName, size: 26)!
-        let scoreCalculateTypeString = NSString(string: "\(scoreCalculateType.calculateTypeString)換算")
+        let scoreCalculateTypeString = NSString(string: "\(scoreCalculateType.typeName)換算")
         let scoreCalculateTypeTextWidth = scoreCalculateTypeString.size(withAttributes: [NSAttributedString.Key.font: scoreCalculateTypeFont]).width
         let scoreCalculateTypeStringX = totalScoreGradeIconX + totalScoreGradeIconWidth - scoreCalculateTypeTextWidth
         let scoreCalculateTypeStringY: CGFloat = 584

--- a/GenshinArtifactScorable/Presentation/Screen/BuildCardGenerator/BuildCardGeneratorViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/BuildCardGenerator/BuildCardGeneratorViewController.swift
@@ -33,7 +33,7 @@ final class BuildCardGeneratorViewController: UIViewController, BuildCardGenerat
     private var isShowingErrorView = false
     
     private var loadingView = LoadingView(with: ())
-    private var errorView = ErrorView(with: ())
+    private var errorView = ErrorView(with: (title: AppConstant.ErrorViewTitle.errorOccured, hideRefreshButton: false))
     
     // MARK: - Lifecycle
     

--- a/GenshinArtifactScorable/Presentation/Screen/Main/ViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/Main/ViewController.swift
@@ -81,8 +81,14 @@ extension ViewController: UITableViewDataSource {
 
 extension ViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        uidTextField.resignFirstResponder()
+        
         let account = cashedAccounts[indexPath.row]
         tableView.deselectRow(at: indexPath, animated: true)
         transitionToSelectCharacterViewController(uid: account.uid)
+    }
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        uidTextField.resignFirstResponder()
     }
 }

--- a/GenshinArtifactScorable/Presentation/Screen/Main/ViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/Main/ViewController.swift
@@ -62,8 +62,7 @@ class ViewController: UIViewController {
     
     @IBAction func uidSendButtonDidTap(_ sender: Any) {
         let uid = uidTextField.text!
-        let viewController = SelectCharacterViewController(with: uid)
-        navigationController?.pushViewController(viewController, animated: true)
+        transitionToSelectCharacterViewController(uid: uid)
     }
 }
 

--- a/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/Component/CharacterCollectionViewCell.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/Component/CharacterCollectionViewCell.swift
@@ -24,7 +24,7 @@ final class CharacterCollectionViewCell: UICollectionViewCell {
 }
 
 extension CharacterCollectionViewCell: NibInstantiatable {
-    func inject(_ dependency: (character: Character, characterIcon: UIImage)) {
+    func inject(_ dependency: (character: Character, characterIcon: UIImage?)) {
         characterImageView.image = dependency.characterIcon
         characterLevelLabel.text = "Lv.\(dependency.character.level)"
         characterBackgroundImageView.image = UIImage(named: dependency.character.quality.characterBackgroundIconString)

--- a/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
@@ -42,13 +42,14 @@ final class SelectCharacterViewController: UIViewController {
     private var shapedAccountAllInfo: ShapedAccountAllInfo?
     
     private var loadingView = LoadingView(with: ())
-    private var errorView = ErrorView(with: ())
+    private var errorView = ErrorView(with: (title: AppConstant.ErrorViewTitle.pleaseRefresh, hideRefreshButton: true))
     
-    private var characterIcons: [UIImage] = []
+    private var characterIcons: [UIImage?] = []
     private var isCharacterIconsLoaded: [Bool] = []
     private var isProfileIconLoaded = false
     private var isNameCardImageLoaded = false
     private var isShowingErrorView = false
+    private var isLoading = false
     
     private var selectedCalculateType: ScoreCalculateType? {
         didSet {
@@ -79,12 +80,17 @@ final class SelectCharacterViewController: UIViewController {
     // MARK: - Private
     
     private func refreshShapedAccountAllInfo() {
+        if isLoading { return }
         showLoadingView()
+        selectedCharacter = nil
         accountService.getAccountAllInfo(uid: uid)
-            .done { shapedAccountAllInfo in
+            .done { shapedAccountAllInfo, apiError in
                 self.shapedAccountAllInfo = shapedAccountAllInfo
-                self.characterIcons = Array(repeating: UIImage(), count: shapedAccountAllInfo.characters.count)
+                self.characterIcons = Array(repeating: nil, count: shapedAccountAllInfo.characters.count)
                 self.setupUI()
+                if let apiError = apiError {
+                    print(apiError)
+                }
             }.catch { error in
                 self.showErrorView()
                 self.hideLoadingView()
@@ -100,11 +106,13 @@ final class SelectCharacterViewController: UIViewController {
         loadingView.frame = view.frame
         view.addSubview(loadingView)
         loadingView.startLoading()
+        isLoading = true
     }
     
     private func hideLoadingView() {
         loadingView.stopLoading()
         loadingView.removeFromSuperview()
+        isLoading = false
     }
     
     private func showErrorView() {
@@ -131,50 +139,44 @@ final class SelectCharacterViewController: UIViewController {
         imageService.fetchUIImage(imageString: shapedAccountAllInfo.playerBasicInfo.profilePictureCharacterIconString)
             .done { profileIconImage in
                 self.profileIconImageView.image = profileIconImage
-                self.isProfileIconLoaded = true
-                if self.isAllUIImagesFetched() { self.hideLoadingView() }
             }.catch { error in
+                self.showErrorView()
+                print(error)
+            }.finally {
                 self.isProfileIconLoaded = true
-                if self.isAllUIImagesFetched() {
-                    self.showErrorView()
+                if self.isAllUIImagesLoaded() {
+                    self.characterCollectionView.reloadData()
                     self.hideLoadingView()
                 }
-                print(error)
             }
         
         imageService.fetchUIImage(imageString: shapedAccountAllInfo.playerBasicInfo.nameCardString)
             .done { nameCardImage in
                 self.namecardImageView.image = nameCardImage
-                self.isNameCardImageLoaded = true
-                if self.isAllUIImagesFetched() { self.hideLoadingView() }
             }.catch { error in
+                self.showErrorView()
+                print(error)
+            }.finally {
                 self.isNameCardImageLoaded = true
-                if self.isAllUIImagesFetched() {
-                    self.showErrorView()
+                if self.isAllUIImagesLoaded() {
+                    self.characterCollectionView.reloadData()
                     self.hideLoadingView()
                 }
-                print(error)
             }
         
         shapedAccountAllInfo.characters.enumerated().forEach { (index, character) in
             imageService.fetchUIImage(imageString: character.iconString)
                 .done { characterIcon in
                     self.characterIcons[index] = characterIcon
-                    self.isCharacterIconsLoaded[index] = true
-                    if self.isCharacterIconsLoaded.allSatisfy({ $0 }) {
-                        self.characterCollectionView.reloadData()
-                    }
-                    if self.isAllUIImagesFetched() { self.hideLoadingView() }
                 }.catch { error in
+                    self.showErrorView()
+                    print(error)
+                }.finally {
                     self.isCharacterIconsLoaded[index] = true
-                    if self.isCharacterIconsLoaded.allSatisfy({ $0 }) {
+                    if self.isAllUIImagesLoaded() {
                         self.characterCollectionView.reloadData()
-                    }
-                    if self.isAllUIImagesFetched() {
-                        self.showErrorView()
                         self.hideLoadingView()
                     }
-                    print(error)
                 }
         }
     }
@@ -192,7 +194,7 @@ final class SelectCharacterViewController: UIViewController {
         fetchImages(shapedAccountAllInfo: shapedAccountAllInfo)
     }
     
-    private func isAllUIImagesFetched() -> Bool {
+    private func isAllUIImagesLoaded() -> Bool {
         return isProfileIconLoaded && isNameCardImageLoaded && isCharacterIconsLoaded.allSatisfy({ $0 })
     }
     
@@ -200,8 +202,8 @@ final class SelectCharacterViewController: UIViewController {
         let actions = ScoreCalculateType.allCases
             .map { scoreCalculateType in
                 UIAction(
-                    title: scoreCalculateType.calculateTypeString,
-                    image: UIImage(named: scoreCalculateType.propIconString)?.withTintColor(.label, renderingMode: .alwaysOriginal),
+                    title: scoreCalculateType.typeName,
+                    image: UIImage(named: scoreCalculateType.typeIconString)?.withTintColor(.label, renderingMode: .alwaysOriginal),
                     state: scoreCalculateType == selectedCalculateType ? .on : .off,
                     handler: { _ in
                         self.selectedCalculateType = scoreCalculateType
@@ -211,7 +213,7 @@ final class SelectCharacterViewController: UIViewController {
         
         selectCalculateTypeButton.menu = UIMenu(title: "スコア計算のタイプ", options: .displayInline, children: actions)
         selectCalculateTypeButton.showsMenuAsPrimaryAction = true
-        selectCalculateTypeButton.setTitle(selectedCalculateType?.calculateTypeString ?? "選択してください", for: .normal)
+        selectCalculateTypeButton.setTitle(selectedCalculateType?.typeName ?? "選択してください", for: .normal)
         
         var configuration = UIButton.Configuration.gray()
         configuration.cornerStyle = .capsule
@@ -223,6 +225,11 @@ final class SelectCharacterViewController: UIViewController {
         selectCalculateTypeButton.configuration = configuration
     }
     
+    // MARK: - Action
+    
+    @IBAction func refreshButtonDidTap(_ sender: Any) {
+        refreshShapedAccountAllInfo()
+    }
     
     @IBAction func generateBuildCardButtonDidTap(_ sender: Any) {
         let buildCardGeneratorViewController = BuildCardGeneratorViewController(with: (character: selectedCharacter!, scoreCalculateType: selectedCalculateType!))
@@ -231,15 +238,17 @@ final class SelectCharacterViewController: UIViewController {
     }
 }
 
+// MARK: - Storyboardable
+
 extension SelectCharacterViewController: Storyboardable {
     func inject(_ dependency: String) {
         self.uid = dependency
         self.accountService = AccountService()
         self.imageService = ImageService()
-        self.characterIcons = Array(repeating: UIImage(), count: shapedAccountAllInfo?.characters.count ?? 0)
-        self.isCharacterIconsLoaded = Array(repeating: false, count: shapedAccountAllInfo?.characters.count ?? 0)
     }
 }
+
+// MARK: - UICollectionViewDataSource
 
 extension SelectCharacterViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -252,12 +261,14 @@ extension SelectCharacterViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeue(CharacterCollectionViewCell.reusable, for: indexPath)
-        if let shapedAccountAllInfo = shapedAccountAllInfo, characterIcons.count == shapedAccountAllInfo.characters.count {
+        if let shapedAccountAllInfo = shapedAccountAllInfo {
             cell.inject((shapedAccountAllInfo.characters[indexPath.row], characterIcons[indexPath.row]))
         }
         return cell
     }
 }
+
+// MARK: - UICollectionViewDelegateFlowLayout
 
 extension SelectCharacterViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -275,6 +286,8 @@ extension SelectCharacterViewController: UICollectionViewDelegateFlowLayout {
         return 0.0
     }
 }
+
+// MARK: - UICollectionViewDelegate
 
 extension SelectCharacterViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
+++ b/GenshinArtifactScorable/Presentation/Screen/SelectCharacter/SelectCharacterViewController.swift
@@ -80,19 +80,14 @@ final class SelectCharacterViewController: UIViewController {
     
     private func refreshShapedAccountAllInfo() {
         showLoadingView()
-        accountService.getAccountAllInfoFromAPI(uid: uid, nextRefreshableDate: shapedAccountAllInfo?.nextRefreshableDate)
-            .done { accountAllInfo in
-                self.shapedAccountAllInfo = accountAllInfo
-                self.characterIcons = Array(repeating: UIImage(), count: accountAllInfo.characters.count)
+        accountService.getAccountAllInfo(uid: uid)
+            .done { shapedAccountAllInfo in
+                self.shapedAccountAllInfo = shapedAccountAllInfo
+                self.characterIcons = Array(repeating: UIImage(), count: shapedAccountAllInfo.characters.count)
                 self.setupUI()
             }.catch { error in
-                if let _ = self.shapedAccountAllInfo {
-                    // 通信に失敗してもキャッシュによりnilでなければUIのセットアップをする
-                    self.setupUI()
-                } else {
-                    self.showErrorView()
-                    self.hideLoadingView()
-                }
+                self.showErrorView()
+                self.hideLoadingView()
                 print(error)
             }
     }
@@ -241,7 +236,6 @@ extension SelectCharacterViewController: Storyboardable {
         self.uid = dependency
         self.accountService = AccountService()
         self.imageService = ImageService()
-        self.shapedAccountAllInfo = accountService.getAccountAllInfoFromRealm(uid: uid)
         self.characterIcons = Array(repeating: UIImage(), count: shapedAccountAllInfo?.characters.count ?? 0)
         self.isCharacterIconsLoaded = Array(repeating: false, count: shapedAccountAllInfo?.characters.count ?? 0)
     }


### PR DESCRIPTION
## 概要
- ユーザ情報の取得先がサーバかキャッシュなのか，ViewController側では知らないようにする
- ユーザ情報画面にて再読み込み機能を追加

## 実装
### ユーザ情報の取得先について
- これまで`getAccountAllInfoFromAPI()`と`getAccountAllInfoFromRealm()`をViewController側で使い分けていたが，ViewController側では取得先を知るべきではないため，`getAccountAllInfo()`関数を作り，基本的にAPIから取得し，失敗した場合はキャッシュから取得するように
- キャッシュから取得した場合でもAPIエラーを受け取るために，`getAccountAllInfo()`の返却型は`Promise<(ShapedAccountAllInfo, Error?)>`とする

### 再読み込み機能について
NavigationBarの右上にボタンを配置し，ボタンを押したら`refreshShapedAccountAllInfo()`を呼ぶ